### PR TITLE
Clean-up CrewList.Post

### DIFF
--- a/src/schemas/Crew.py
+++ b/src/schemas/Crew.py
@@ -15,7 +15,7 @@ def validatePhone(phone):
 
 class CrewSchema(Marshmallow().Schema):
     id = fields.Integer(dump_only=True)
-    nickname = fields.String(required=True)
-    email = fields.String(required=True)
-    phone = fields.String(required=True, validate=validatePhone)
+    nickname = fields.String(required=True, unique=True)
+    email = fields.String(required=True, unique=True)
+    phone = fields.String(required=True, unique=True, validate=validatePhone)
     is_admin = fields.Boolean(missing=False)


### PR DESCRIPTION
Istället för att kolla varje kolumn en-efter-en (vilket ger 3st SELECTs) så kör man en INSERT och hanterar felen.

La även till unique-constraints i modellen så att SQLAlchemy vet att dom ska vara unika.